### PR TITLE
support setNoDelay and setTimeout for WiFi connection

### DIFF
--- a/Redis.cpp
+++ b/Redis.cpp
@@ -8,6 +8,8 @@ Redis::Redis(const char *addr, int port)
 {
     this->addr = addr;
     this->port = port;
+    this->NoDelay = false;
+    this->Timeout = 100;
 }
 
 /**
@@ -41,6 +43,9 @@ bool Redis::begin(const char *password)
 {
     if(this->conn.connect(this->addr, this->port)) 
     {
+        // the NoDelay and Timeout should be specified prior to making the connection
+        this->conn.setNoDelay(this->NoDelay);
+        this->conn.setTimeout(this->Timeout);
         int passwordLength = strlen(password);
         if (passwordLength > 0)
         {
@@ -57,6 +62,44 @@ bool Redis::begin(const char *password)
         return true;
     }
     return false;
+}
+
+/**
+ * Set the noDelay option for the ESP8266 WiFi Client
+ * @param val true or false
+ * @return If it's okay.
+ */
+bool Redis::setNoDelay(bool val)
+{
+    if (this->conn.connected())
+    {
+        // It should be specified prior to making the connection
+        return false;
+    }
+    else
+    {
+        this->NoDelay = val;
+        return true;
+    }
+}
+
+/**
+ * Set the Timeout option for the ESP8266 WiFi Client
+ * @param val timeout duration in milliseconds (long)
+ * @return If it's okay.
+ */
+bool Redis::setTimeout(long val)
+{
+    if (this->conn.connected())
+    {
+        // It should be specified prior to making the connection
+        return false;
+    }
+    else
+    {
+        this->Timeout = val;
+        return true;
+    }
 }
 
 /**

--- a/Redis.h
+++ b/Redis.h
@@ -7,6 +7,8 @@ class Redis {
   private:
     const char* addr;
     int         port;
+    int         Timeout;
+    bool        NoDelay;
     WiFiClient  conn;
     String      checkError(String);
   public:
@@ -14,6 +16,8 @@ class Redis {
     bool    begin(void);
     bool    begin(const char *);
     bool    set(const char *, const char *);
+    bool    setNoDelay(bool val);
+    bool    setTimeout(long val);
     String  get(const char *);
     int     publish(const char *, const char *);
     //bool    subscribe(char *);


### PR DESCRIPTION
I noticed when doing 

```
redis.set("foo", "1");
delay(1000);
redis.set("foo", "2");
delay(1000);
redis.set("foo", "3");
delay(1000);
redis.set("foo", "4");
delay(1000);
```

that it would take some 5 seconds between each of the 1, 2, 3, 4 appearing in my database (using "redis-cli monitor"). 

I first thought it was due to the Angle algorithm, hence I implemented the http://arduino-esp8266.readthedocs.io/en/latest/esp8266wifi/client-class.html. That did not solve it (but it is in this PR, as it might be useful for others).

I traced the problem further down to the "conn.readStringUntil".  Upon the first read attempt, there is no data yet. The read command then seems to pause for 5 seconds before trying again. This can be solved using the https://www.arduino.cc/en/Reference/StreamSetTimeout command.

This PR allows for
```
redis.setNoDelay(bool)
redis.setTimeout(long)
```
which both should be called prior to redis.begin()

 